### PR TITLE
fixed a bug of env.env.action in Demo_ABIDES-Gym

### DIFF
--- a/notebooks/Demo_ABIDES-Gym.ipynb
+++ b/notebooks/Demo_ABIDES-Gym.ipynb
@@ -259,7 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "env.env.action_space"
+    "env.action_space"
    ]
   },
   {


### PR DESCRIPTION
There is a bug in the notebook where the 'env' is called recursively. 
This makes the sentence run into error, if someone use the notebook.