### PR TITLE
fix a bug in abides-market exchange agent of ABM is fixed in orderbook

### DIFF
--- a/abides-markets/abides_markets/agents/exchange_agent.py
+++ b/abides-markets/abides_markets/agents/exchange_agent.py
@@ -254,10 +254,16 @@ class ExchangeAgent(FinancialAgent):
         super().kernel_terminating()
         # print(self.order_books['ABM'].book_log2)
         # If the oracle supports writing the fundamental value series for its
-        bid_volume, ask_volume = self.order_books["ABM"].get_transacted_volume(
-            self.current_time - self.mkt_open
-        )
-        self.total_exchanged_volume = bid_volume + ask_volume
+        #bid_volume, ask_volume = self.order_books["ABM"].get_transacted_volume(
+        #    self.current_time - self.mkt_open
+        #)
+        #self.total_exchanged_volume = bid_volume + ask_volume
+        self.total_exchanged_volume = 0      
+        for symbol in self.symbols:
+            bid_volume, ask_volume = self.order_books[symbol].get_transacted_volume(
+                self.current_time - self.mkt_open
+            )
+            self.total_exchanged_volume += bid_volume + ask_volume
 
         # symbols, write them to disk.
         for symbol in self.symbols:


### PR DESCRIPTION
This bug will make the kernel.run() fails if the user feeds a symbol with its value not equal to "ABM". Like this:
```python
# it is ok for the existing code
symbol = "ABM"
# it will fail and meets KeyError: 'ABM'
symbol = "Code111"
agents.extend([ExchangeAgent(id=0,
                        name="EXCHANGE_AGENT",
                        mkt_open=mkt_open,
                        mkt_close=mkt_close,
                        symbols=[symbol],
                        book_logging=False, #
                        book_log_depth=10,
                        log_orders=True,
                        pipeline_delay=0,
                        computation_delay=0,
                        stream_history=25_000,
                             )
               ]
              )
```